### PR TITLE
Fixed getMissingParams(now check reqParams=null)

### DIFF
--- a/swaggerClient/swaggerClient.html
+++ b/swaggerClient/swaggerClient.html
@@ -191,8 +191,9 @@ pre {
                     //console.log('type is a definition');
                     var model = type.match(/<span class="strong">(.*?)\{/g)[0];
                     model = model.substring(model.indexOf('<span class="strong">') + 21, model.lastIndexOf('{')).trim();
-                    type = model;
+                    type  = model;
                     var model = getModel(model);
+                    model.id   = id;
                     model.info = info;
                     return model
                 } else{
@@ -228,7 +229,7 @@ pre {
                         currProp.items = parseArrayItems(currProp.items);
                         //console.log(currProp.items);
                     } else{
-                        //console.log('found something simple... ' + p + ' with type: ' + currProp.type);
+                        console.log('found something simple... ' + p + ' with type: ' + currProp.type);
                     }
                     parsedProps[p] = currProp;
                 }
@@ -281,14 +282,16 @@ pre {
             function addModelParamRowToTable(param){
                 
                 var convertedParam = convertObjectToText(param);
-                
+                console.log(param);
                 $('#swaggerclient-paramslisttable').find('tbody')
                     .append($('<tr>', {class: 'paramRow'})
                         .append($('<td>')
                             .append($('<span>', {class: 'paramId'})
-                                .text(param.model_id)
+                                .text(param.id)
+                                //.text(param.model_id)
                             )
                             .append($('<div>', {style: 'font-size:8px; margin-left: 20px'})
+                                .text(param.model_id)
                                 .text(param.info)
                             )
                         )
@@ -332,6 +335,7 @@ pre {
                     }
                     convertedObj[p] = type;
                 }
+                console.log(convertedObj);
                 return convertedObj;
             }
             

--- a/swaggerClient/swaggerClient.js
+++ b/swaggerClient/swaggerClient.js
@@ -22,28 +22,37 @@ module.exports = function(RED) {
             console.log('Swagger URL: ' + url);
             //console.log('api: ' + api);
             //console.log('resource: ' + resource);
-            //console.log('params: ' + JSON.stringify(params));
+            //console.log('params: ');
+            //console.log(params);
             
             if(params && params['_isModel']){
+                var messageBody = {};
                 for(var key in params){
                     if(key != '_isModel'){
                         try{
-                            params = {
-                                body: JSON.parse(params[key])
-                            }
+                            //params = {
+                            //    body: JSON.parse(params[key])
+                            //}
+                            messageBody = JSON.parse(params[key]);
+                            params.body = params[key];
+                            //params[key] = JSON.parse(params[key]);
                         } catch(e){
-                            node.error('Bad JSON in object: ' + key, msg);
-                            return;
+                            //node.error('Bad JSON in object: ' + key, msg);
+                            //return;
+                            console.log('No JSON in object: ' + key);
+                            //console.log(params[key]);
                         }
-                        
                     }
                 }
             }
-            
+            //console.log('final params:');
+            //console.log(params);
+    
+            //var client = new Swagger({
             var client = new swaggerjs.SwaggerClient({
                 url: url,
                 success: function() {
-                    
+                    client.clientAuthorizations.add("api_key", new swaggerjs.ApiKeyAuthorization("_apikey", params._apikey, "query"));
                     //Check for missing params
                     var missingParams = getMissingParams(findApiReqParams(api, resource, client.apisArray), params);
                     
@@ -51,6 +60,8 @@ module.exports = function(RED) {
                         node.error('Missing params: ' + missingParams.toString(), msg);
                         return;
                     } else{
+                        //console.log('Client params:');
+                        //console.log(params);
                         client[api][resource](params, {responseContentType: 'application/json'}, function(resp){
                             msg.statusCode = resp.status;
                             msg.payload = resp.obj;
@@ -67,6 +78,12 @@ module.exports = function(RED) {
                 failure: function(err) {
                     node.error(err, msg);
                     return;
+                },
+                authorizations : {
+                    //easyapi_basic  : new client.PasswordAuthorization('<username>', '<password>'),
+                    //someHeaderAuth : new client.ApiKeyAuthorization('<nameOfHeader>', '<value>', 'header'),
+                    "apiKey"  : new swaggerjs.ApiKeyAuthorization('_apikey', '_apikey', 'query')
+                    //someCookieAuth : new client.CookieAuthorization('<cookie>'),
                 }
             })
         });
@@ -83,6 +100,8 @@ module.exports = function(RED) {
                                 reqParams.push(apisArray[i].operationsArray[j].operation.parameters[k].name);
                             }
                         }
+                        //console.log('required Params:');
+                        //console.log(reqParams);
                         return reqParams;
                     }
                 }
@@ -104,6 +123,8 @@ module.exports = function(RED) {
                 missingParams.push(reqParams[i]);
             }
         }
+        //console.log('missing Params:');
+        //console.log(missingParams);
         return(missingParams || null);
     }
     

--- a/swaggerClient/swaggerClient.js
+++ b/swaggerClient/swaggerClient.js
@@ -92,6 +92,10 @@ module.exports = function(RED) {
     
     function getMissingParams(reqParams, params){
         var missingParams;
+        if ( ! reqParams )
+        {
+            return null;
+        }
         for(var i=0; i< reqParams.length; i++){
             if(!(params && params.hasOwnProperty(reqParams[i]))){
                 if(!missingParams){

--- a/swaggerClient/swaggerClient.js
+++ b/swaggerClient/swaggerClient.js
@@ -9,17 +9,17 @@ module.exports = function(RED) {
         RED.nodes.createNode(this,config);
         var node = this;
         this.on('input', function(msg) {
-            var url = config.url || msg.url;
-            var api = config.api || msg.api;
-            var resource = config.resource || msg.resource;
-            var params = config.params || msg.params;
+            var url      = msg.url || config.url;
+            var api      = msg.api || config.api;
+            var resource = msg.resource || config.resource;
+            var params   = msg.params || config.params;
             
             if(! (url && api && resource)){
                 node.error('Missing configuration values', msg);
                 return;
             }
             
-            console.log('url: ' + url);
+            console.log('Swagger URL: ' + url);
             //console.log('api: ' + api);
             //console.log('resource: ' + resource);
             //console.log('params: ' + JSON.stringify(params));


### PR DESCRIPTION
Fixed error: if reqParams is not an array - reqParams.length is undefined: in this case getMissingParams() throws an error for ANY swagger API method that has no required params.
